### PR TITLE
Added Anthropic's end_turn as a valid finish reason

### DIFF
--- a/packages/modelfusion/src/model-function/generate-text/TextGenerationResult.ts
+++ b/packages/modelfusion/src/model-function/generate-text/TextGenerationResult.ts
@@ -17,5 +17,5 @@ export type TextGenerationFinishReason =
   | "tool-calls"
   | "error"
   | "other"
-  | "end_turn
+  | "end_turn"
   | "unknown";

--- a/packages/modelfusion/src/model-function/generate-text/TextGenerationResult.ts
+++ b/packages/modelfusion/src/model-function/generate-text/TextGenerationResult.ts
@@ -17,4 +17,5 @@ export type TextGenerationFinishReason =
   | "tool-calls"
   | "error"
   | "other"
+  | "end_turn
   | "unknown";


### PR DESCRIPTION
Generating text using Anthropic's models through OpenRouter crashes because their finish reason is "end_turn". 

As I just debugged this quickly, I'm not sure if there are other places where this needs to be added?

```
TypeValidationError: Type validation failed: Value: {"id":"gen-xxx","model":"anthropic/claude-3-opus","object":"chat.completion","created":1716730125,"choices":[{"index":0,"message":{"role":"assistant","content":"Hello! How can I assist you today?"},"finish_reason":"end_turn"}],"usage":{"prompt_tokens":10,"completion_tokens":12,"total_tokens":22}}.
Error message: [
  {
    "received": "end_turn",
    "code": "invalid_enum_value",
    "options": [
      "stop",
      "length",
      "tool_calls",
      "content_filter",
      "function_call"
    ],
    "path": [
      "choices",
      0,
      "finish_reason"
    ],
    "message": "Invalid enum value. Expected 'stop' | 'length' | 'tool_calls' | 'content_filter' | 'function_call', received 'end_turn'"
  }
]
 cause: {
  "issues": [
    {
      "received": "end_turn",
      "code": "invalid_enum_value",
      "options": [
        "stop",
        "length",
        "tool_calls",
        "content_filter",
        "function_call"
      ],
      "path": [
        "choices",
        0,
        "finish_reason"
      ],
      "message": "Invalid enum value. Expected 'stop' | 'length' | 'tool_calls' | 'content_filter' | 'function_call', received 'end_turn'"
    }
  ],
  "name": "ZodError"
}
```